### PR TITLE
Switched to a more performant locking library

### DIFF
--- a/NiconicoToolkit.Net5/NiconicoToolkit.Net5.csproj
+++ b/NiconicoToolkit.Net5/NiconicoToolkit.Net5.csproj
@@ -12,9 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.16.0" />
+    <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.0.0" />
     <PackageReference Include="Macross.Json.Extensions" Version="2.0.0" />
-    <PackageReference Include="NeoSmart.AsyncLock" Version="3.1.0" />
     <PackageReference Include="System.ServiceModel.Syndication" Version="6.0.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
     <PackageReference Include="U8XmlParser" Version="1.4.0" />

--- a/NiconicoToolkit.Shared/Live/WatchSession/Live2WatchSession.cs
+++ b/NiconicoToolkit.Shared/Live/WatchSession/Live2WatchSession.cs
@@ -7,13 +7,13 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using NeoSmart.AsyncLock;
 using NiconicoToolkit.Live.WatchSession;
 using System.Text.Json.Serialization;
 using System.Text.Unicode;
 using System.Text.Encodings.Web;
 using NiconicoToolkit.Live.WatchSession.ToClientMessage;
 using System.Net.WebSockets;
+using AsyncKeyedLock;
 
 namespace NiconicoToolkit.Live.WatchSession
 {
@@ -108,7 +108,7 @@ namespace NiconicoToolkit.Live.WatchSession
     public sealed class Live2WatchSession : IDisposable
     {
         private readonly ClientWebSocket _ws;
-        private readonly AsyncLock _WebSocketLock = new AsyncLock();
+        private readonly AsyncNonKeyedLocker _WebSocketLock = new AsyncNonKeyedLocker();
         public readonly bool IsWatchWithTimeshift;
         private readonly string _webSocketUrl;
         private readonly JsonSerializerOptions _SocketJsonDeserializerOptions;
@@ -231,6 +231,7 @@ namespace NiconicoToolkit.Live.WatchSession
         public async void Dispose()
         {
             _ws.Dispose();
+            _WebSocketLock.Dispose();
             await CloseAsync();
         }
 

--- a/NiconicoToolkit.Shared/Live/WatchSession/LiveCommentSession.cs
+++ b/NiconicoToolkit.Shared/Live/WatchSession/LiveCommentSession.cs
@@ -15,7 +15,7 @@ using System.Net.WebSockets;
 
 namespace NiconicoToolkit.Live.WatchSession
 {
-    using AsyncLock = NeoSmart.AsyncLock.AsyncLock;
+    using AsyncLock = AsyncKeyedLock.AsyncNonKeyedLocker;
 
     public static class NiwavidedNicoLiveMessageHelper
     {
@@ -195,6 +195,7 @@ namespace NiconicoToolkit.Live.WatchSession
             _connectionCts?.Cancel();
             _connectionCts?.Dispose();
             _ws?.Dispose();
+            _CommentSessionLock.Dispose();
             StopHeartbeatTimer();
             StopCommentPullTimingTimer();
         }

--- a/NiconicoToolkit.Shared/Live/WatchSession/WatchSessionTimer.cs
+++ b/NiconicoToolkit.Shared/Live/WatchSession/WatchSessionTimer.cs
@@ -1,5 +1,4 @@
-﻿using NeoSmart.AsyncLock;
-using NiconicoToolkit.Live.WatchPageProp;
+﻿using NiconicoToolkit.Live.WatchPageProp;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/NiconicoToolkit.WinUI3/NiconicoToolkit.WinUI3.csproj
+++ b/NiconicoToolkit.WinUI3/NiconicoToolkit.WinUI3.csproj
@@ -10,11 +10,11 @@
 
   <ItemGroup>
       <PackageReference Include="AngleSharp" Version="0.16.0" />
+      <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
       <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.0.0" />
       <PackageReference Include="Macross.Json.Extensions" Version="2.0.0" />
       <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
       <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.194" />
-      <PackageReference Include="NeoSmart.AsyncLock" Version="3.1.0" />
       <PackageReference Include="System.ServiceModel.Syndication" Version="6.0.0" />
       <PackageReference Include="System.Text.Json" Version="5.0.2" />
       <PackageReference Include="U8XmlParser" Version="1.4.0" />


### PR DESCRIPTION
Disclaimer: I am the author of the new library.

Public benchmarks running on GitHub show AsyncNonKeyedLocker to be considerably more performant; in tests NeoSmart.AsyncLock took 9.71x the time and allocated 7.42x the memory.

https://github.com/MarkCiliaVincenti/AsyncNonKeyedLockBenchmarks/actions/runs/7526873065/job/20485876144